### PR TITLE
Fix sanitizePostBase translations handling

### DIFF
--- a/src/libs/utils/language.ts
+++ b/src/libs/utils/language.ts
@@ -80,10 +80,12 @@ export const availableLanguagesFromContents = (contents: PostContent[]) => {
   )
 }
 
-export const sanitizePostBase = (post: TPostBase): TPostBase => ({
-  ...post,
-  translations: undefined,
-})
+type PostWithOptionalTranslations = TPostBase & { translations?: TPostBase[] }
+
+export const sanitizePostBase = (post: PostWithOptionalTranslations): TPostBase => {
+  const { translations: _translations, ...rest } = post
+  return rest
+}
 
 export const selectPostBaseByLanguage = (
   post: TPost,


### PR DESCRIPTION
## Summary
- update sanitizePostBase to strip the translations field instead of setting it to undefined
- ensure helper accepts post inputs that may include optional translations

## Testing
- yarn build *(fails: blocked from fetching Google Fonts in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc8cfbdc08328824ec4c02102ba2e