### PR TITLE
Use local emoji font stack

### DIFF
--- a/src/apis/notion-client/getPosts.ts
+++ b/src/apis/notion-client/getPosts.ts
@@ -13,6 +13,9 @@ import { TPosts } from "src/types"
 // TODO: react query를 사용해서 처음 불러온 뒤로는 해당데이터만 사용하도록 수정
 export const getPosts = async () => {
   let id = CONFIG.notionConfig.pageId as string
+  if (!id) {
+    return []
+  }
   const api = new NotionAPI()
 
   const response = await api.getPage(id)

--- a/src/assets/fonts/roboto/index.ts
+++ b/src/assets/fonts/roboto/index.ts
@@ -1,7 +1,9 @@
-import { Roboto } from 'next/font/google'
+const robotoFontStack = '"Roboto", system-ui, -apple-system, BlinkMacSystemFont, sans-serif'
 
-export const roboto = Roboto({
-  weight: ['900'],
-  style: ['italic'],
-  subsets: ['latin'],
-})
+export const roboto = {
+  style: {
+    fontFamily: robotoFontStack,
+    fontWeight: "900" as const,
+    fontStyle: "italic" as const,
+  },
+}

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,11 +1,7 @@
-import React, { ReactNode } from "react"
-import { Noto_Color_Emoji } from "next/font/google"
+import { ReactNode } from "react"
 
-const notoColorEmoji = Noto_Color_Emoji({
-  weight: ["400"],
-  subsets: ["emoji"],
-  fallback: ["Apple Color Emoji"],
-})
+const emojiFontStack =
+  '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Twemoji", sans-serif'
 
 type Props = {
   className?: string
@@ -14,7 +10,7 @@ type Props = {
 
 export const Emoji = ({ className, children }: Props) => {
   return (
-    <span className={className} css={[notoColorEmoji.style]}>
+    <span className={className} style={{ fontFamily: emojiFontStack }}>
       {children}
     </span>
   )


### PR DESCRIPTION
## Summary
- remove next/font usage from the Emoji component and use a system emoji font stack
- replace the Roboto next/font configuration with a static font stack to avoid network fetches
- guard Notion post fetching when no page ID is configured so builds can complete offline

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68ccd2732a0c8328908d21b7709a6dfa