### PR TITLE
Improve language detection fallback

### DIFF
--- a/docs/manual-verification/useLanguage.md
+++ b/docs/manual-verification/useLanguage.md
@@ -1,0 +1,22 @@
+# Manual Verification - Language Auto-Detection
+
+These steps verify the language initialization logic when no language cookie is present.
+
+## Prerequisites
+
+- Run the application locally via `yarn dev`.
+- Open the site in a private/incognito browsing session so no previous language cookie exists.
+
+## Scenario: Browser reports `en-US`
+
+1. In the browser DevTools console, execute `navigator.__defineGetter__('languages', () => ['en-US'])` and `navigator.__defineGetter__('language', () => 'en-US')`.
+2. Reload the page.
+3. Confirm that the interface renders in English (e.g., headings and navigation labels appear in English).
+
+## Scenario: Browser reports `ko-KR`
+
+1. In the DevTools console, execute `navigator.__defineGetter__('languages', () => ['ko-KR'])` and `navigator.__defineGetter__('language', () => 'ko-KR')`.
+2. Reload the page.
+3. Confirm that the interface remains in Korean (e.g., headings and navigation labels appear in Korean).
+
+Reset your DevTools overrides or restart the browser session after completing the checks.

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -4,6 +4,7 @@ import { getCookie, setCookie } from "cookies-next"
 import { useEffect } from "react"
 import { DEFAULT_LANGUAGE } from "src/constants/language"
 import { queryKey } from "src/constants/queryKey"
+import { deriveDefaultLanguage } from "src/libs/utils/language"
 
 type SetLanguage = (language: string) => void
 
@@ -30,7 +31,23 @@ const useLanguage = (): [string, SetLanguage] => {
     if (typeof window === "undefined") return
 
     const cachedLanguage = getCookie(LANGUAGE_COOKIE_KEY) as string | undefined
-    setLanguage(cachedLanguage || DEFAULT_LANGUAGE)
+    if (cachedLanguage) {
+      setLanguage(cachedLanguage)
+      return
+    }
+
+    const availableLanguages =
+      Array.isArray(navigator.languages) && navigator.languages.length > 0
+        ? navigator.languages
+        : navigator.language
+        ? [navigator.language]
+        : []
+
+    const normalizedLanguage = availableLanguages
+      .map((language) => deriveDefaultLanguage(language))
+      .find((language) => language === "ko" || language === "en")
+
+    setLanguage(normalizedLanguage ?? DEFAULT_LANGUAGE)
   }, [setLanguage])
 
   return [data ?? DEFAULT_LANGUAGE, setLanguage]


### PR DESCRIPTION
## Summary
- ensure the language hook falls back to navigator locales when no cookie is cached
- normalize browser-provided locales through deriveDefaultLanguage before selecting ko/en
- document manual verification steps for en-US and ko-KR browser configurations

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd657ceac88328a69cbbeaa8c74d5f