### PR TITLE
Add visitor analytics and Google-auth comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Next.js static blog using Notion as a Content Management System (CMS). Supports 
    - `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` : For Google search console Plugin.
    - `NEXT_PUBLIC_NAVER_SITE_VERIFICATION` : For Naver search advisor Plugin.
    - `NEXT_PUBLIC_UTTERANCES_REPO` : For Utterances Plugin.
+   - `NEXT_PUBLIC_GOOGLE_CLIENT_ID` : Required for Google comment authentication.
+   - `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` : Required to persist visitor statistics and comments using Upstash Redis REST API.
+   - `VISITOR_TIMEZONE` *(optional)* and `NEXT_PUBLIC_VISITOR_TIMEZONE` *(optional)* : Override the default `Asia/Seoul` timezone when aggregating visitor statistics both on the server and client.
 
 ## 10 Steps to build your own morethan-log (by 23.06.23)
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,12 @@
 module.exports = {
   images: {
-    domains: ['www.notion.so', 'lh5.googleusercontent.com', 's3-us-west-2.amazonaws.com'],
+    domains: [
+      'www.notion.so',
+      'lh3.googleusercontent.com',
+      'lh4.googleusercontent.com',
+      'lh5.googleusercontent.com',
+      'lh6.googleusercontent.com',
+      's3-us-west-2.amazonaws.com',
+    ],
   },
 }

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -5,4 +5,6 @@ export const queryKey = {
   tags: () => ["tags"],
   categories: () => ["categories"],
   post: (slug: string) => ["post", slug],
+  visitorStats: () => ["visitorStats"],
+  comments: (slug: string) => ["comments", slug],
 }

--- a/src/libs/comments/index.ts
+++ b/src/libs/comments/index.ts
@@ -1,0 +1,31 @@
+import { runRedisCommand } from "src/libs/upstash"
+import type { StoredComment } from "src/types/comment"
+
+const COMMENT_PREFIX = "comments:"
+
+const getCommentKey = (slug: string) => `${COMMENT_PREFIX}${slug}`
+
+export const fetchComments = async (slug: string) => {
+  const key = getCommentKey(slug)
+  const raw = (await runRedisCommand(["GET", key])) as string | null
+  if (!raw) return [] as StoredComment[]
+
+  try {
+    const parsed = JSON.parse(raw) as StoredComment[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch (error) {
+    console.error("Failed to parse stored comments", error)
+    return []
+  }
+}
+
+export const storeComments = async (slug: string, comments: StoredComment[]) => {
+  const key = getCommentKey(slug)
+  await runRedisCommand(["SET", key, JSON.stringify(comments)])
+}
+
+export const appendComment = async (slug: string, comment: StoredComment) => {
+  const comments = await fetchComments(slug)
+  comments.push(comment)
+  await storeComments(slug, comments)
+}

--- a/src/libs/google/verifyIdToken.ts
+++ b/src/libs/google/verifyIdToken.ts
@@ -1,0 +1,35 @@
+const GOOGLE_TOKEN_INFO_ENDPOINT = "https://oauth2.googleapis.com/tokeninfo"
+
+export type GoogleTokenInfo = {
+  aud: string
+  sub: string
+  email?: string
+  email_verified?: string
+  name?: string
+  picture?: string
+  exp?: string
+  iat?: string
+}
+
+export const verifyGoogleIdToken = async (token: string) => {
+  if (!token) {
+    throw new Error("Missing Google ID token")
+  }
+
+  const url = `${GOOGLE_TOKEN_INFO_ENDPOINT}?id_token=${encodeURIComponent(token)}`
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new Error("Failed to verify Google token")
+  }
+
+  const payload = (await response.json()) as GoogleTokenInfo
+
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
+
+  if (clientId && payload.aud !== clientId) {
+    throw new Error("Token audience mismatch")
+  }
+
+  return payload
+}

--- a/src/libs/upstash/index.ts
+++ b/src/libs/upstash/index.ts
@@ -1,0 +1,130 @@
+const { UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN } = process.env
+
+const hasUpstashConfig = Boolean(
+  UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN
+)
+
+type Command = string[]
+
+type MemoryEntry = {
+  value: string
+  expiresAt?: number
+}
+
+type MemoryStore = Map<string, MemoryEntry>
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __IN_MEMORY_REDIS__: MemoryStore | undefined
+}
+
+const getMemoryStore = (): MemoryStore => {
+  const globalObject = globalThis as { __IN_MEMORY_REDIS__?: MemoryStore }
+  if (!globalObject.__IN_MEMORY_REDIS__) {
+    globalObject.__IN_MEMORY_REDIS__ = new Map<string, MemoryEntry>()
+  }
+  return globalObject.__IN_MEMORY_REDIS__
+}
+
+const normalizeResult = (input: any): any => {
+  if (Array.isArray(input)) {
+    return input.map((item) => normalizeResult(item))
+  }
+  if (input && typeof input === "object" && "result" in input) {
+    return normalizeResult((input as any).result)
+  }
+  return input
+}
+
+const executeInMemory = (command: Command) => {
+  const [action, ...args] = command
+  const store = getMemoryStore()
+
+  switch (action) {
+    case "GET": {
+      const entry = store.get(args[0])
+      if (!entry) return null
+      if (entry.expiresAt && entry.expiresAt < Date.now()) {
+        store.delete(args[0])
+        return null
+      }
+      return entry.value
+    }
+    case "SET": {
+      const key = args[0]
+      const value = args[1]
+      store.set(key, { value })
+      return "OK"
+    }
+    case "INCRBY": {
+      const key = args[0]
+      const increment = Number(args[1])
+      const currentEntry = store.get(key)
+      const currentValue = currentEntry ? Number(currentEntry.value) : 0
+      const nextValue = currentValue + increment
+      store.set(key, { value: String(nextValue) })
+      return nextValue
+    }
+    case "EXPIRE": {
+      const key = args[0]
+      const seconds = Number(args[1])
+      const entry = store.get(key)
+      if (!entry) return 0
+      entry.expiresAt = Date.now() + seconds * 1000
+      store.set(key, entry)
+      return 1
+    }
+    case "MGET": {
+      return args.map((key) => executeInMemory(["GET", key]))
+    }
+    default: {
+      throw new Error(`Unsupported in-memory redis command: ${action}`)
+    }
+  }
+}
+
+export const runRedisCommand = async (command: Command) => {
+  if (!hasUpstashConfig) {
+    return executeInMemory(command)
+  }
+
+  const response = await fetch(UPSTASH_REDIS_REST_URL as string, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ command }),
+  })
+
+  const payload = await response.json()
+
+  if (!response.ok) {
+    throw new Error(payload.error || "Failed to execute redis command")
+  }
+
+  return normalizeResult(payload.result)
+}
+
+export const runRedisPipeline = async (commands: Command[]) => {
+  if (!hasUpstashConfig) {
+    return commands.map((command) => executeInMemory(command))
+  }
+
+  const response = await fetch(UPSTASH_REDIS_REST_URL as string, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ commands }),
+  })
+
+  const payload = await response.json()
+
+  if (!response.ok) {
+    throw new Error(payload.error || "Failed to execute redis pipeline")
+  }
+
+  return normalizeResult(payload.results ?? payload.result ?? [])
+}

--- a/src/libs/utils/date.ts
+++ b/src/libs/utils/date.ts
@@ -1,0 +1,27 @@
+const DEFAULT_TIME_ZONE = "Asia/Seoul"
+
+export const getDateKeyForTimeZone = (
+  date: Date,
+  timeZone: string = DEFAULT_TIME_ZONE
+) => {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date)
+}
+
+export const getTodayKey = (timeZone: string = DEFAULT_TIME_ZONE) => {
+  return getDateKeyForTimeZone(new Date(), timeZone)
+}
+
+export const getOffsetDateKey = (
+  offsetDays: number,
+  timeZone: string = DEFAULT_TIME_ZONE,
+  baseDate: Date = new Date()
+) => {
+  const base = new Date(baseDate.getTime())
+  base.setUTCDate(base.getUTCDate() + offsetDays)
+  return getDateKeyForTimeZone(base, timeZone)
+}

--- a/src/pages/api/comments.ts
+++ b/src/pages/api/comments.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from "crypto"
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { appendComment, fetchComments } from "src/libs/comments"
+import { verifyGoogleIdToken } from "src/libs/google/verifyIdToken"
+import type {
+  CommentResponse,
+  CreateCommentRequest,
+  StoredComment,
+} from "src/types/comment"
+
+const MAX_COMMENT_LENGTH = 2000
+
+const parseRequestBody = (body: unknown): CreateCommentRequest | null => {
+  if (!body || typeof body !== "object") return null
+
+  const value = body as Partial<CreateCommentRequest>
+
+  if (
+    typeof value.postId !== "string" ||
+    typeof value.postSlug !== "string" ||
+    typeof value.postTitle !== "string" ||
+    typeof value.content !== "string"
+  ) {
+    return null
+  }
+
+  return {
+    postId: value.postId.trim(),
+    postSlug: value.postSlug.trim(),
+    postTitle: value.postTitle.trim(),
+    content: value.content.trim(),
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CommentResponse | StoredComment | { message: string }>
+) {
+  if (req.method === "GET") {
+    const slugParam = req.query.slug
+
+    if (!slugParam || typeof slugParam !== "string") {
+      return res.status(400).json({ message: "Missing slug" })
+    }
+
+    const comments = await fetchComments(slugParam)
+    return res.status(200).json({ comments })
+  }
+
+  if (req.method === "POST") {
+    try {
+      const authHeader = req.headers.authorization
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        return res.status(401).json({ message: "Missing credentials" })
+      }
+
+      const token = authHeader.replace("Bearer ", "")
+      const payload = await verifyGoogleIdToken(token)
+      const body = parseRequestBody(req.body)
+
+      if (!body) {
+        return res.status(400).json({ message: "Invalid request body" })
+      }
+
+      if (!body.content) {
+        return res.status(400).json({ message: "Comment cannot be empty" })
+      }
+
+      if (body.content.length > MAX_COMMENT_LENGTH) {
+        return res.status(400).json({ message: "Comment is too long" })
+      }
+
+      const comment: StoredComment = {
+        id: randomUUID(),
+        postId: body.postId,
+        postSlug: body.postSlug,
+        postTitle: body.postTitle,
+        content: body.content,
+        createdAt: new Date().toISOString(),
+        author: {
+          id: payload.sub,
+          name: payload.name || payload.email || "Anonymous",
+          picture: payload.picture,
+          email: payload.email,
+        },
+      }
+
+      await appendComment(body.postSlug, comment)
+
+      return res.status(201).json(comment)
+    } catch (error) {
+      console.error("Failed to create comment", error)
+      return res.status(401).json({ message: "Invalid Google authentication" })
+    }
+  }
+
+  res.setHeader("Allow", "GET,POST")
+  return res.status(405).json({ message: "Method Not Allowed" })
+}

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { runRedisCommand, runRedisPipeline } from "src/libs/upstash"
+import { getDateKeyForTimeZone, getOffsetDateKey } from "src/libs/utils/date"
+import type { VisitorStats } from "src/types/analytics"
+
+const DEFAULT_TIME_ZONE = process.env.VISITOR_TIMEZONE || "Asia/Seoul"
+const TOTAL_KEY = "visitors:total"
+
+const getDailyKey = (dateKey: string) => `visitors:daily:${dateKey}`
+
+const buildStats = (values: (string | number | null)[]): VisitorStats => {
+  const [totalRaw, todayRaw, yesterdayRaw] = values
+  return {
+    total: Number(totalRaw ?? 0),
+    today: Number(todayRaw ?? 0),
+    yesterday: Number(yesterdayRaw ?? 0),
+  }
+}
+
+const readStats = async () => {
+  const now = new Date()
+  const todayKey = getDateKeyForTimeZone(now, DEFAULT_TIME_ZONE)
+  const yesterdayKey = getOffsetDateKey(-1, DEFAULT_TIME_ZONE, now)
+
+  const result = (await runRedisCommand([
+    "MGET",
+    TOTAL_KEY,
+    getDailyKey(todayKey),
+    getDailyKey(yesterdayKey),
+  ])) as (string | null)[]
+
+  return buildStats(result)
+}
+
+const recordVisit = async () => {
+  const now = new Date()
+  const todayKey = getDateKeyForTimeZone(now, DEFAULT_TIME_ZONE)
+  const yesterdayKey = getOffsetDateKey(-1, DEFAULT_TIME_ZONE, now)
+  const dailyKey = getDailyKey(todayKey)
+
+  const [totalResult, todayResult] = (await runRedisPipeline([
+    ["INCRBY", TOTAL_KEY, "1"],
+    ["INCRBY", dailyKey, "1"],
+    ["EXPIRE", dailyKey, String(60 * 60 * 24 * 60)],
+  ])) as (number | string)[]
+
+  const yesterdayValue = (await runRedisCommand([
+    "GET",
+    getDailyKey(yesterdayKey),
+  ])) as string | null
+
+  return buildStats([
+    totalResult,
+    todayResult,
+    yesterdayValue,
+  ])
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<VisitorStats | { message: string }>
+) {
+  try {
+    if (req.method === "GET") {
+      const stats = await readStats()
+      return res.status(200).json(stats)
+    }
+
+    if (req.method === "POST") {
+      const stats = await recordVisit()
+      return res.status(200).json(stats)
+    }
+
+    res.setHeader("Allow", "GET,POST")
+    return res.status(405).json({ message: "Method Not Allowed" })
+  } catch (error) {
+    console.error("Failed to handle visitor stats", error)
+    return res.status(500).json({ message: "Failed to process visitor stats" })
+  }
+}

--- a/src/routes/Detail/PostDetail/CommentBox/GoogleComments.tsx
+++ b/src/routes/Detail/PostDetail/CommentBox/GoogleComments.tsx
@@ -1,0 +1,497 @@
+import Image from "next/image"
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import styled from "@emotion/styled"
+
+import { queryKey } from "src/constants/queryKey"
+import type { StoredComment } from "src/types/comment"
+import type { TPostBase } from "src/types"
+
+const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
+const DISPLAY_TIME_ZONE =
+  process.env.NEXT_PUBLIC_VISITOR_TIMEZONE || "Asia/Seoul"
+
+let googleClientInitialized = false
+
+interface GoogleCredentialPayload {
+  sub: string
+  name?: string
+  email?: string
+  picture?: string
+}
+
+type GoogleUser = {
+  id: string
+  name: string
+  email?: string
+  picture?: string
+  credential: string
+}
+
+type CredentialResponse = {
+  credential: string
+}
+
+type RenderButtonOptions = {
+  theme?: "outline" | "filled_blue" | "filled_black"
+  size?: "small" | "medium" | "large"
+  text?: "signin_with" | "signup_with" | "continue_with" | "signin"
+  shape?: "rectangular" | "pill" | "circle" | "square"
+  width?: string
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        id?: {
+          initialize: (config: {
+            client_id: string
+            callback: (response: CredentialResponse) => void
+          }) => void
+          renderButton: (
+            parent: HTMLElement,
+            options: RenderButtonOptions
+          ) => void
+          prompt: () => void
+          disableAutoSelect: () => void
+        }
+      }
+    }
+  }
+}
+
+const decodeCredential = (credential: string): GoogleCredentialPayload => {
+  const payload = credential.split(".")[1]
+  if (!payload) throw new Error("Invalid credential token")
+
+  const normalized = payload.replace(/-/g, "+").replace(/_/g, "/")
+  const decoded = atob(normalized)
+  const json = decodeURIComponent(
+    decoded
+      .split("")
+      .map((char) => `%${("00" + char.charCodeAt(0).toString(16)).slice(-2)}`)
+      .join("")
+  )
+  return JSON.parse(json) as GoogleCredentialPayload
+}
+
+const fetchComments = async (slug: string) => {
+  const response = await fetch(`/api/comments?slug=${encodeURIComponent(slug)}`)
+  if (!response.ok) {
+    throw new Error("Failed to fetch comments")
+  }
+
+  const payload = (await response.json()) as { comments: StoredComment[] }
+  return Array.isArray(payload.comments) ? payload.comments : []
+}
+
+const initializeGoogleSdk = (
+  callback: (response: CredentialResponse) => void,
+  onReady: () => void
+) => {
+  if (typeof window === "undefined" || !GOOGLE_CLIENT_ID) return
+
+  const initClient = () => {
+    if (!window.google?.accounts?.id) return
+    if (!googleClientInitialized) {
+      window.google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback,
+      })
+      googleClientInitialized = true
+    }
+    onReady()
+  }
+
+  const existingScript = document.getElementById(
+    "google-identity-services"
+  ) as HTMLScriptElement | null
+
+  if (existingScript) {
+    if (existingScript.dataset.loaded === "true") {
+      initClient()
+    } else {
+      const handleLoad = () => {
+        existingScript.dataset.loaded = "true"
+        initClient()
+      }
+      existingScript.addEventListener("load", handleLoad, { once: true })
+    }
+    return
+  }
+
+  const script = document.createElement("script")
+  script.id = "google-identity-services"
+  script.src = "https://accounts.google.com/gsi/client"
+  script.async = true
+  script.defer = true
+  script.onload = () => {
+    script.dataset.loaded = "true"
+    initClient()
+  }
+  document.body.appendChild(script)
+}
+
+const GoogleComments: React.FC<{ data: Pick<TPostBase, "id" | "slug" | "title"> }> = ({
+  data,
+}) => {
+  const queryClient = useQueryClient()
+  const [user, setUser] = useState<GoogleUser | null>(null)
+  const [comment, setComment] = useState("")
+  const [sdkReady, setSdkReady] = useState(false)
+  const buttonRef = useRef<HTMLDivElement | null>(null)
+
+  const {
+    data: comments = [],
+    isLoading,
+    isError,
+  } = useQuery<StoredComment[]>(
+    queryKey.comments(data.slug),
+    () => fetchComments(data.slug),
+    {
+      initialData: [],
+      staleTime: 30 * 1000,
+    }
+  )
+
+  useEffect(() => {
+    if (!GOOGLE_CLIENT_ID) return
+
+    initializeGoogleSdk((response) => {
+      try {
+        const payload = decodeCredential(response.credential)
+        setUser({
+          id: payload.sub,
+          name: payload.name || payload.email || "Anonymous",
+          email: payload.email,
+          picture: payload.picture,
+          credential: response.credential,
+        })
+      } catch (error) {
+        console.error("Failed to decode Google credential", error)
+      }
+    }, () => setSdkReady(true))
+  }, [])
+
+  useEffect(() => {
+    if (!sdkReady || user || !buttonRef.current) return
+    if (!window.google?.accounts?.id) return
+
+    buttonRef.current.innerHTML = ""
+    window.google.accounts.id.renderButton(buttonRef.current, {
+      theme: "outline",
+      size: "large",
+      text: "signin_with",
+      width: "100%",
+    })
+  }, [sdkReady, user])
+
+  const mutation = useMutation<StoredComment, Error, string>(
+    async (content) => {
+      if (!user) throw new Error("Google 인증 후 댓글을 남길 수 있어요.")
+
+      const response = await fetch("/api/comments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${user.credential}`,
+        },
+        body: JSON.stringify({
+          postId: data.id,
+          postSlug: data.slug,
+          postTitle: data.title,
+          content,
+        }),
+      })
+
+      const payload = await response.json().catch(() => null)
+
+      if (!response.ok || !payload) {
+        const message =
+          (payload && typeof payload === "object" && "message" in payload
+            ? (payload as { message?: string }).message
+            : undefined) || "댓글 등록에 실패했어요."
+        throw new Error(message)
+      }
+
+      return payload as StoredComment
+    },
+    {
+      onSuccess: (created) => {
+        queryClient.setQueryData<StoredComment[]>(
+          queryKey.comments(data.slug),
+          (prev = []) => [...prev, created]
+        )
+        setComment("")
+      },
+    }
+  )
+
+  const sortedComments = useMemo(
+    () =>
+      [...comments].sort((a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      ),
+    [comments]
+  )
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const value = comment.trim()
+    if (!value) return
+    mutation.mutate(value)
+  }
+
+  const handleSignOut = () => {
+    window.google?.accounts?.id?.disableAutoSelect?.()
+    setUser(null)
+  }
+
+  const submissionError =
+    mutation.error instanceof Error ? mutation.error.message : null
+
+  const formatDate = (value: string) => {
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return ""
+    return date.toLocaleString("ko-KR", { timeZone: DISPLAY_TIME_ZONE })
+  }
+
+  return (
+    <Wrapper>
+      <header>
+        <h3>Comments</h3>
+        {user ? (
+          <div className="profile">
+            {user.picture && (
+              <Image
+                src={user.picture}
+                alt={user.name}
+                width={32}
+                height={32}
+                style={{ borderRadius: "9999px", objectFit: "cover" }}
+              />
+            )}
+            <span>{user.name}</span>
+            <button type="button" onClick={handleSignOut}>
+              Sign out
+            </button>
+          </div>
+        ) : GOOGLE_CLIENT_ID ? (
+          <div className="signin" ref={buttonRef} />
+        ) : (
+          <div className="notice">
+            Google 로그인 클라이언트 ID가 설정되어 있지 않아요.
+          </div>
+        )}
+      </header>
+
+      <Form onSubmit={handleSubmit}>
+        <textarea
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          placeholder={
+            user
+              ? "따뜻한 댓글을 남겨주세요."
+              : "Google 로그인 후 댓글을 남길 수 있어요."
+          }
+          disabled={!user || mutation.isLoading}
+          rows={4}
+        />
+        <div className="actions">
+          <button
+            type="submit"
+            disabled={!user || mutation.isLoading || !comment.trim()}
+          >
+            {mutation.isLoading ? "Posting…" : "Post comment"}
+          </button>
+        </div>
+        {submissionError && <p className="error">{submissionError}</p>}
+      </Form>
+
+      <section>
+        {isLoading && <p className="info">Loading comments…</p>}
+        {isError && (
+          <p className="error">댓글을 불러오지 못했어요. 잠시 후 다시 시도해주세요.</p>
+        )}
+        {!isLoading && !isError && sortedComments.length === 0 && (
+          <p className="info">아직 댓글이 없어요. 첫 댓글을 남겨보세요!</p>
+        )}
+        <ul>
+          {sortedComments.map((item) => (
+            <li key={item.id}>
+              <div className="meta">
+                {item.author.picture && (
+                  <Image
+                    src={item.author.picture}
+                    alt={item.author.name}
+                    width={36}
+                    height={36}
+                    style={{ borderRadius: "9999px", objectFit: "cover" }}
+                  />
+                )}
+                <div>
+                  <div className="name">{item.author.name}</div>
+                  <div className="date">{formatDate(item.createdAt)}</div>
+                </div>
+              </div>
+              <p className="content">{item.content}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </Wrapper>
+  )
+}
+
+export default GoogleComments
+
+const Wrapper = styled.div`
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    h3 {
+      font-size: 1.125rem;
+      font-weight: 600;
+    }
+
+    .profile {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+
+      span {
+        font-weight: 500;
+      }
+
+      button {
+        margin-left: auto;
+        background: transparent;
+        border: none;
+        color: ${({ theme }) => theme.colors.gray11};
+        cursor: pointer;
+        font-size: 0.875rem;
+
+        :hover {
+          color: ${({ theme }) => theme.colors.gray12};
+        }
+      }
+    }
+
+    .notice {
+      font-size: 0.875rem;
+      color: ${({ theme }) => theme.colors.red10};
+    }
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .info {
+      font-size: 0.875rem;
+      color: ${({ theme }) => theme.colors.gray11};
+    }
+
+    .error {
+      font-size: 0.875rem;
+      color: ${({ theme }) => theme.colors.red10};
+    }
+
+    ul {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      li {
+        padding: 1rem;
+        border-radius: 1rem;
+        background-color: ${({ theme }) =>
+          theme.scheme === "light" ? theme.colors.gray3 : theme.colors.gray5};
+
+        .meta {
+          display: flex;
+          gap: 0.75rem;
+          align-items: center;
+          margin-bottom: 0.75rem;
+
+          .name {
+            font-weight: 600;
+          }
+
+          .date {
+            font-size: 0.75rem;
+            color: ${({ theme }) => theme.colors.gray11};
+          }
+        }
+
+        .content {
+          line-height: 1.6;
+          white-space: pre-wrap;
+        }
+      }
+    }
+  }
+`
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  textarea {
+    width: 100%;
+    padding: 0.75rem;
+    border-radius: 1rem;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    resize: vertical;
+    font-size: 0.95rem;
+    min-height: 120px;
+    background-color: ${({ theme }) =>
+      theme.scheme === "light" ? "white" : theme.colors.gray4};
+
+    :disabled {
+      background-color: ${({ theme }) => theme.colors.gray5};
+      cursor: not-allowed;
+    }
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+
+    button {
+      padding: 0.5rem 1.25rem;
+      border-radius: 9999px;
+      border: none;
+      background-color: ${({ theme }) => theme.colors.gray12};
+      color: white;
+      cursor: pointer;
+      font-weight: 500;
+
+      :disabled {
+        background-color: ${({ theme }) => theme.colors.gray7};
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .error {
+    font-size: 0.875rem;
+    color: ${({ theme }) => theme.colors.red10};
+  }
+`

--- a/src/routes/Detail/PostDetail/CommentBox/index.tsx
+++ b/src/routes/Detail/PostDetail/CommentBox/index.tsx
@@ -1,31 +1,19 @@
-import { TPostBase } from "src/types"
-import { CONFIG } from "site.config"
 import dynamic from "next/dynamic"
 
-const UtterancesComponent = dynamic(
-  () => {
-    return import("./Utterances")
-  },
-  { ssr: false }
-)
-const CusdisComponent = dynamic(
-  () => {
-    return import("./Cusdis")
-  },
-  { ssr: false }
-)
+import type { TPostBase } from "src/types"
 
 type Props = {
   data: Pick<TPostBase, "id" | "slug" | "title">
 }
 
+const GoogleComments = dynamic(() => import("./GoogleComments"), {
+  ssr: false,
+})
+
 const CommentBox: React.FC<Props> = ({ data }) => {
   return (
     <div>
-      {CONFIG.utterances.enable && <UtterancesComponent issueTerm={data.id} />}
-      {CONFIG.cusdis.enable && (
-        <CusdisComponent id={data.id} slug={data.slug} title={data.title} />
-      )}
+      <GoogleComments data={data} />
     </div>
   )
 }

--- a/src/routes/Feed/ServiceCard.tsx
+++ b/src/routes/Feed/ServiceCard.tsx
@@ -1,34 +1,171 @@
-import { CONFIG } from "site.config"
-import React from "react"
-import { AiFillCodeSandboxCircle } from "react-icons/ai"
+import { useEffect } from "react"
+
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import styled from "@emotion/styled"
+import { AiFillCodeSandboxCircle } from "react-icons/ai"
+
 import { Emoji } from "src/components/Emoji"
+import { queryKey } from "src/constants/queryKey"
+import { getDateKeyForTimeZone } from "src/libs/utils/date"
+import type { VisitorStats } from "src/types/analytics"
+import { CONFIG } from "site.config"
+
+const VISITOR_TIMEZONE =
+  process.env.NEXT_PUBLIC_VISITOR_TIMEZONE || "Asia/Seoul"
+const LAST_VISIT_STORAGE_KEY = "visitor:last-visit"
+
+const fetchVisitorStats = async (): Promise<VisitorStats> => {
+  const response = await fetch("/api/visits")
+  if (!response.ok) {
+    throw new Error("Failed to fetch visitor stats")
+  }
+  return (await response.json()) as VisitorStats
+}
+
+const recordVisit = async (): Promise<VisitorStats | null> => {
+  const response = await fetch("/api/visits", { method: "POST" })
+  if (!response.ok) {
+    return null
+  }
+  return (await response.json()) as VisitorStats
+}
 
 const ServiceCard: React.FC = () => {
-  if (!CONFIG.projects) return null
+  const queryClient = useQueryClient()
+  const {
+    data: stats,
+    isLoading,
+    isError,
+  } = useQuery(queryKey.visitorStats(), fetchVisitorStats, {
+    staleTime: 1000 * 60,
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const todayKey = getDateKeyForTimeZone(new Date(), VISITOR_TIMEZONE)
+    const stored = localStorage.getItem(LAST_VISIT_STORAGE_KEY)
+
+    if (stored === todayKey) return
+
+    recordVisit()
+      .then((updated) => {
+        if (updated) {
+          queryClient.setQueryData(queryKey.visitorStats(), updated)
+          localStorage.setItem(LAST_VISIT_STORAGE_KEY, todayKey)
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to record visit", error)
+      })
+  }, [queryClient])
+
+  const projects = CONFIG.projects ?? []
+  const hasProjects = projects.length > 0
+
   return (
     <>
-      <StyledTitle>
-        <Emoji>🌟</Emoji> Service
-      </StyledTitle>
-      <StyledWrapper>
-        {CONFIG.projects.map((project, idx) => (
-          <a
-            key={idx}
-            href={`${project.href}`}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <AiFillCodeSandboxCircle className="icon" />
-            <div className="name">{project.name}</div>
-          </a>
-        ))}
-      </StyledWrapper>
+      <StatsWrapper>
+        <div className="title">
+          <Emoji>👥</Emoji> Visitors
+        </div>
+        {isLoading && <div className="description">Loading visitor data…</div>}
+        {isError && (
+          <div className="description error">
+            Unable to load visitor statistics right now.
+          </div>
+        )}
+        {!isLoading && !isError && stats && (
+          <div className="grid">
+            <div>
+              <div className="label">Yesterday</div>
+              <div className="value">{stats.yesterday.toLocaleString()}</div>
+            </div>
+            <div>
+              <div className="label">Today</div>
+              <div className="value">{stats.today.toLocaleString()}</div>
+            </div>
+            <div>
+              <div className="label">Total</div>
+              <div className="value">{stats.total.toLocaleString()}</div>
+            </div>
+          </div>
+        )}
+      </StatsWrapper>
+      {hasProjects && (
+        <>
+          <StyledTitle>
+            <Emoji>🌟</Emoji> Service
+          </StyledTitle>
+          <StyledWrapper>
+            {projects.map((project, idx) => (
+              <a
+                key={idx}
+                href={`${project.href}`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <AiFillCodeSandboxCircle className="icon" />
+                <div className="name">{project.name}</div>
+              </a>
+            ))}
+          </StyledWrapper>
+        </>
+      )}
     </>
   )
 }
 
 export default ServiceCard
+
+const StatsWrapper = styled.div`
+  padding: 0.75rem;
+  margin-bottom: 1.5rem;
+  border-radius: 1rem;
+  background-color: ${({ theme }) =>
+    theme.scheme === "light" ? "white" : theme.colors.gray4};
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+
+  .title {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+  }
+
+  .description {
+    font-size: 0.75rem;
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  .description.error {
+    color: ${({ theme }) => theme.colors.red10};
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+
+    > div {
+      padding: 0.5rem;
+      border-radius: 0.75rem;
+      background-color: ${({ theme }) => theme.colors.gray5};
+
+      .label {
+        font-size: 0.75rem;
+        color: ${({ theme }) => theme.colors.gray11};
+        margin-bottom: 0.25rem;
+      }
+
+      .value {
+        font-size: 1rem;
+        font-weight: 600;
+      }
+    }
+  }
+`
 
 const StyledTitle = styled.div`
   padding: 0.25rem;

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,5 @@
+export type VisitorStats = {
+  today: number
+  yesterday: number
+  total: number
+}

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,0 +1,27 @@
+export type CommentAuthor = {
+  id: string
+  name: string
+  picture?: string
+  email?: string
+}
+
+export type StoredComment = {
+  id: string
+  postId: string
+  postSlug: string
+  postTitle: string
+  content: string
+  createdAt: string
+  author: CommentAuthor
+}
+
+export type CommentResponse = {
+  comments: StoredComment[]
+}
+
+export type CreateCommentRequest = {
+  postId: string
+  postSlug: string
+  postTitle: string
+  content: string
+}


### PR DESCRIPTION
## Summary
- add a visitor statistics API backed by Upstash (with in-memory fallback) and surface the numbers above the Service section
- create a Google Identity based comment box with REST persistence and React Query integration
- document the new environment variables and allow Google profile image domains for Next.js Image

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68ce541abf948328aaafb710de734431