### PR TITLE
Define reusable in-memory redis result type

### DIFF
--- a/src/libs/upstash/index.ts
+++ b/src/libs/upstash/index.ts
@@ -6,6 +6,12 @@ const hasUpstashConfig = Boolean(
 
 type Command = string[]
 
+type InMemoryRedisValue =
+  | string
+  | number
+  | null
+  | InMemoryRedisValue[]
+
 type MemoryEntry = {
   value: string
   expiresAt?: number
@@ -36,7 +42,7 @@ const normalizeResult = (input: any): any => {
   return input
 }
 
-const executeInMemory = (command: Command) => {
+const executeInMemory = (command: Command): InMemoryRedisValue => {
   const [action, ...args] = command
   const store = getMemoryStore()
 
@@ -83,7 +89,9 @@ const executeInMemory = (command: Command) => {
   }
 }
 
-export const runRedisCommand = async (command: Command) => {
+export const runRedisCommand = async (
+  command: Command,
+): Promise<InMemoryRedisValue> => {
   if (!hasUpstashConfig) {
     return executeInMemory(command)
   }
@@ -106,7 +114,9 @@ export const runRedisCommand = async (command: Command) => {
   return normalizeResult(payload.result)
 }
 
-export const runRedisPipeline = async (commands: Command[]) => {
+export const runRedisPipeline = async (
+  commands: Command[],
+): Promise<InMemoryRedisValue> => {
   if (!hasUpstashConfig) {
     return commands.map((command) => executeInMemory(command))
   }


### PR DESCRIPTION
## Summary
- add a reusable type alias describing in-memory Redis command results
- apply the alias to executeInMemory to keep recursive calls strongly typed
- update runRedisCommand and runRedisPipeline to return the new type consistently

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d088afae888328b001a6fca565abd0